### PR TITLE
Bug fixes

### DIFF
--- a/omnikey.safariextension/js/global.js
+++ b/omnikey.safariextension/js/global.js
@@ -10,12 +10,8 @@ var trackEvent = function(data)
 var createUrl = function(url, query)
 {
     var new_url
-
     query = encodeURIComponent(query)
-    query = query.replace(/%20/g, '+')
-
     new_url = url.replace(/\{search\}/g, query)
-    new_url = new_url.replace(/\{%search\}/g, query.replace(/\+/g, '%20'))
 
     return new_url
 }

--- a/omnikey.safariextension/js/settings.js
+++ b/omnikey.safariextension/js/settings.js
@@ -213,7 +213,7 @@
         },
 
         importData: function (json_data) {
-            this.add(json_data)
+            this.add(JSON.parse(json_data))
             this.each(function(Site)
             {
                 Site.save()


### PR DESCRIPTION
Currently, safari-omnikey substitutes blank characters in the query to '+' signs, and it usually brings unwanted results. e.g.) Wikipedia
this commit fixes this behavior, as well as a bug fix of importing JSON data.
